### PR TITLE
add support for Kirby Air Ride, Twilight Princess

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * Super Smash Bros. Melee (NTSC v1.2, PAL, [20XX](https://smashboards.com/threads/the-20xx-melee-training-hack-pack-v4-07-7-04-17.351221/), [UnclePunch Training Mode](https://github.com/UnclePunch/Training-Mode), [Slippi](https://slippi.gg))
 * Super Smash Bros. Brawl (NTSC v1.0, NTSC v1.1, NTSC v1.2, [Project M](https://en.wikipedia.org/wiki/Project_M), [P+](https://projectplusgame.com/))
 * The SpongeBob SquarePants Movie (NTSC v1.1, PAL v1.0)
-* Kirby Air Ride (NTSC v1.0)
+* Kirby Air Ride (NTSC-U v1.0, NTSC-J v1.0)
 
 *More games can be supported upon request!*
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * Super Smash Bros. Melee (NTSC v1.2, PAL, [20XX](https://smashboards.com/threads/the-20xx-melee-training-hack-pack-v4-07-7-04-17.351221/), [UnclePunch Training Mode](https://github.com/UnclePunch/Training-Mode), [Slippi](https://slippi.gg))
 * Super Smash Bros. Brawl (NTSC v1.0, NTSC v1.1, NTSC v1.2, [Project M](https://en.wikipedia.org/wiki/Project_M), [P+](https://projectplusgame.com/))
 * The SpongeBob SquarePants Movie (NTSC v1.1, PAL v1.0)
-* Kirby Air Ride (NTSC-U v1.0, NTSC-J v1.0)
+* Kirby Air Ride (NTSC-U v1.0, NTSC-J v1.0, [UnclePunch Hack Pack](https://www.kirbyairri.de/hpinfo.html))
 
 *More games can be supported upon request!*
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * Need for Speed Underground 1 (NTSC v1.0)
 * Need for Speed Underground 2 (NTSC v1.0)
 * The Legend of Zelda: The Wind Waker (NTSC v1.0)
-* The Legend of Zelda: Twilight Princess (GC NTSC v1.0, Wii NTSC v1.0)
+* The Legend of Zelda: Twilight Princess (GC NTSC v1.0, PAL v1.0, Wii NTSC v1.0)
 * Luigi's Mansion (NTSC v1.0)
 * Metroid Prime (NTSC v1.0, NTSC v1.2)
 * Metroid Prime 2 - Echoes (NTSC v1.0, [Randomizer](https://github.com/randovania/randovania))

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * Super Smash Bros. Melee (NTSC v1.2, PAL, [20XX](https://smashboards.com/threads/the-20xx-melee-training-hack-pack-v4-07-7-04-17.351221/), [UnclePunch Training Mode](https://github.com/UnclePunch/Training-Mode), [Slippi](https://slippi.gg))
 * Super Smash Bros. Brawl (NTSC v1.0, NTSC v1.1, NTSC v1.2, [Project M](https://en.wikipedia.org/wiki/Project_M), [P+](https://projectplusgame.com/))
 * The SpongeBob SquarePants Movie (NTSC v1.1, PAL v1.0)
+* Kirby Air Ride (NTSC v1.0)
 
 *More games can be supported upon request!*
 

--- a/source/main.lua
+++ b/source/main.lua
@@ -423,7 +423,7 @@ function love.drawControllerOverlay()
 	if controller then
 		-- Draw Joystick
 
-		if controller.plugged and controller.plugged ~= 0x00 then
+		if controller.plugged and controller.plugged ~= (memory.isKirbyAirRide() and 0x01 or 0x00) then
 			local sin = 128 + math.sin(love.timer.getTime()*2) * 128
 			graphics.setColor(255, 0, 0, sin)
 			graphics.easyDraw(DC_CON, 512-42-16, 256-42-16, 0, 42, 42)

--- a/source/modules/games/GKYE01-0.lua
+++ b/source/modules/games/GKYE01-0.lua
@@ -1,0 +1,56 @@
+-- Kirby Air Ride (NTSC 1.0)
+
+local game = {
+	memorymap = {}
+}
+
+local addr = 0x8058B0E4
+local off = 0x44
+
+local controllers = {
+	[1] = addr + off * 0,
+	[2] = addr + off * 1,
+	[3] = addr + off * 2,
+	[4] = addr + off * 3,
+}
+
+-- Notably similar addresses to Melee, which makes sense since both games are made by HAL.
+local controller_struct = {
+	[0x00] = { type = "int",	name = "controller.%d.buttons.pressed" },
+	[0x20] = { type = "float",	name = "controller.%d.joystick.x" },
+	[0x24] = { type = "float",	name = "controller.%d.joystick.y" },
+	[0x28] = { type = "float",	name = "controller.%d.cstick.x" },
+	[0x2C] = { type = "float",	name = "controller.%d.cstick.y" },
+	[0x30] = { type = "float",	name = "controller.%d.analog.l" },
+	[0x34] = { type = "float",	name = "controller.%d.analog.r" },
+	[0x44] = { type = "byte",	name = "controller.%d.plugged" },
+
+	-- A note about plugged:
+	-- Byte 0x41 of each controller from 0x00 to 0x01 only after the 
+	-- controller has been plugged in or the game was started with the 
+	-- controller plugged in, however, the overlay does not seem to
+	-- detect this behavior, therefore showing all controllers regardless
+	-- of memory status as unplugged.
+
+	-- Melee has a similar issue, but instead of setting byte 0x41 to 0x01,
+	-- it starts as 0xFF and gets set to 0x00. 
+
+	-- To avoid this issue altogether, I've decided to set the plugged bit
+	-- to 0x44 which is always 0x00, thus showing all controllers as plugged
+	-- in.
+}
+
+for port, address in ipairs(controllers) do
+	for offset, info in pairs(controller_struct) do
+		game.memorymap[address + offset] = {
+			type = info.type,
+			debug = info.debug,
+			name = info.name:format(port),
+		}
+	end
+end
+
+game.translateAxis = function(x, y) return x, y end
+game.translateTriggers = function(l, r) return l, r end
+
+return game

--- a/source/modules/games/GKYE01-0.lua
+++ b/source/modules/games/GKYE01-0.lua
@@ -23,7 +23,7 @@ local controller_struct = {
 	[0x2C] = { type = "float",	name = "controller.%d.cstick.y" },
 	[0x30] = { type = "float",	name = "controller.%d.analog.l" },
 	[0x34] = { type = "float",	name = "controller.%d.analog.r" },
-	[0x44] = { type = "byte",	name = "controller.%d.plugged" },
+	[0x41] = { type = "byte",	name = "controller.%d.plugged" },
 
 	-- A note about plugged:
 	-- Byte 0x41 of each controller is set from 0x00 to 0x01 only after the 
@@ -35,9 +35,9 @@ local controller_struct = {
 	-- Melee has a similar issue, but instead of setting byte 0x41 to 0x01,
 	-- it starts as 0xFF and gets set to 0x00. 
 
-	-- To avoid this issue altogether, I've decided to set the plugged bit
-	-- to 0x44 which is always 0x00, thus showing all controllers as plugged
-	-- in.
+	-- I've fixed this issue by detecting whether or not the current game is
+	-- Kirby Air Ride and changing the number to compare against from 0x00 to
+	-- 0x01 for Kirby Air Ride only.
 }
 
 for port, address in ipairs(controllers) do

--- a/source/modules/games/GKYE01-0.lua
+++ b/source/modules/games/GKYE01-0.lua
@@ -26,7 +26,7 @@ local controller_struct = {
 	[0x44] = { type = "byte",	name = "controller.%d.plugged" },
 
 	-- A note about plugged:
-	-- Byte 0x41 of each controller from 0x00 to 0x01 only after the 
+	-- Byte 0x41 of each controller is set from 0x00 to 0x01 only after the 
 	-- controller has been plugged in or the game was started with the 
 	-- controller plugged in, however, the overlay does not seem to
 	-- detect this behavior, therefore showing all controllers regardless

--- a/source/modules/games/GKYJ01-0.lua
+++ b/source/modules/games/GKYJ01-0.lua
@@ -23,7 +23,7 @@ local controller_struct = {
 	[0x2C] = { type = "float",	name = "controller.%d.cstick.y" },
 	[0x30] = { type = "float",	name = "controller.%d.analog.l" },
 	[0x34] = { type = "float",	name = "controller.%d.analog.r" },
-	[0x44] = { type = "byte",	name = "controller.%d.plugged" },
+	[0x41] = { type = "byte",	name = "controller.%d.plugged" },
 
 	-- A note about plugged:
 	-- Byte 0x41 of each controller is set from 0x00 to 0x01 only after the 
@@ -35,9 +35,9 @@ local controller_struct = {
 	-- Melee has a similar issue, but instead of setting byte 0x41 to 0x01,
 	-- it starts as 0xFF and gets set to 0x00. 
 
-	-- To avoid this issue altogether, I've decided to set the plugged bit
-	-- to 0x44 which is always 0x00, thus showing all controllers as plugged
-	-- in.
+	-- I've fixed this issue by detecting whether or not the current game is
+	-- Kirby Air Ride and changing the number to compare against from 0x00 to
+	-- 0x01 for Kirby Air Ride only.
 }
 
 for port, address in ipairs(controllers) do

--- a/source/modules/games/GKYJ01-0.lua
+++ b/source/modules/games/GKYJ01-0.lua
@@ -1,0 +1,56 @@
+-- Kirby's Airride (NTSC-J v1.0)
+
+local game = {
+	memorymap = {}
+}
+
+local addr = 0x80585B64
+local off = 0x44
+
+local controllers = {
+	[1] = addr + off * 0,
+	[2] = addr + off * 1,
+	[3] = addr + off * 2,
+	[4] = addr + off * 3,
+}
+
+-- Notably similar addresses to Melee, which makes sense since both games are made by HAL.
+local controller_struct = {
+	[0x00] = { type = "int",	name = "controller.%d.buttons.pressed" },
+	[0x20] = { type = "float",	name = "controller.%d.joystick.x" },
+	[0x24] = { type = "float",	name = "controller.%d.joystick.y" },
+	[0x28] = { type = "float",	name = "controller.%d.cstick.x" },
+	[0x2C] = { type = "float",	name = "controller.%d.cstick.y" },
+	[0x30] = { type = "float",	name = "controller.%d.analog.l" },
+	[0x34] = { type = "float",	name = "controller.%d.analog.r" },
+	[0x44] = { type = "byte",	name = "controller.%d.plugged" },
+
+	-- A note about plugged:
+	-- Byte 0x41 of each controller is set from 0x00 to 0x01 only after the 
+	-- controller has been plugged in or the game was started with the 
+	-- controller plugged in, however, the overlay does not seem to
+	-- detect this behavior, therefore showing all controllers regardless
+	-- of memory status as unplugged.
+
+	-- Melee has a similar issue, but instead of setting byte 0x41 to 0x01,
+	-- it starts as 0xFF and gets set to 0x00. 
+
+	-- To avoid this issue altogether, I've decided to set the plugged bit
+	-- to 0x44 which is always 0x00, thus showing all controllers as plugged
+	-- in.
+}
+
+for port, address in ipairs(controllers) do
+	for offset, info in pairs(controller_struct) do
+		game.memorymap[address + offset] = {
+			type = info.type,
+			debug = info.debug,
+			name = info.name:format(port),
+		}
+	end
+end
+
+game.translateAxis = function(x, y) return x, y end
+game.translateTriggers = function(l, r) return l, r end
+
+return game

--- a/source/modules/games/GZ2P01-0.lua
+++ b/source/modules/games/GZ2P01-0.lua
@@ -1,0 +1,15 @@
+-- The Legend of Zelda - Twilight Princess (PAL v1.0)
+
+-- The motivation behind adding PAL version support is that most
+-- speedrunners run on the PAL version of the game, since German
+-- is the fastest language.
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+core.loadGenericControllerMap(0x804363B0, game)
+
+return game

--- a/source/modules/games/clones.lua
+++ b/source/modules/games/clones.lua
@@ -8,4 +8,5 @@ return {
 	["SDRE32"] = { id = "GALE01", version = 2 }, -- SSBM SD Remix
 	["RSBE01"] = { id = "RSBE01", version = 2 }, -- Super Smash Bros. Brawl
 	["G2ME0R"] = { id = "G2ME01", version = 0 }, -- Metroid Prime 2: Echoes Randomizer
+	["KHPE01"] = { id = "GKYE01", version = 0 }, -- Kirby Air Ride Hack Pack
 }

--- a/source/modules/memory/init.lua
+++ b/source/modules/memory/init.lua
@@ -333,6 +333,10 @@ function watcher.isMelee()
 	return gid == "GALE01"
 end
 
+function watcher.isKirbyAirRide()
+	return (watcher.gameid == "GKYE01" or watcher.gameid == "GKYJ01")
+end
+
 function watcher.runhooks()
 	local pop
 	while true do

--- a/source/modules/memory/init.lua
+++ b/source/modules/memory/init.lua
@@ -334,7 +334,12 @@ function watcher.isMelee()
 end
 
 function watcher.isKirbyAirRide()
-	return (watcher.gameid == "GKYE01" or watcher.gameid == "GKYJ01")
+	local gid = watcher.gameid
+
+	local clone = clones[gid]
+	if clone then gid = clone.id end
+
+	return (gid == "GKYE01" or gid == "GKYJ01")
 end
 
 function watcher.runhooks()


### PR DESCRIPTION
Added support for Kirby Air Ride NTSC-U v1.0, NTSC-J v1.0.

Added support for Twilight Princess (GC PAL v1.0)

Be sure to read the comments in the Kirby Air Ride files about the plugged issue I fixed.