### PR TITLE
Add support for Super Monkey Ball, Mario Kart Wii

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * Super Smash Bros. Brawl (NTSC v1.0, NTSC v1.1, NTSC v1.2, [Project M](https://en.wikipedia.org/wiki/Project_M), [P+](https://projectplusgame.com/))
 * The SpongeBob SquarePants Movie (NTSC v1.1, PAL v1.0)
 * Kirby Air Ride (NTSC-U v1.0, NTSC-J v1.0, [UnclePunch Hack Pack](https://www.kirbyairri.de/hpinfo.html))
+* Super Monkey Ball (NTSC-U v1.0, NTSC-J v1.2, PAL v1.0)
 
 *More games can be supported upon request!*
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * The SpongeBob SquarePants Movie (NTSC v1.1, PAL v1.0)
 * Kirby Air Ride (NTSC-U v1.0, NTSC-J v1.0, [UnclePunch Hack Pack](https://www.kirbyairri.de/hpinfo.html))
 * Super Monkey Ball (NTSC-U v1.0, NTSC-J v1.2, PAL v1.0)
-* Mario Kart Wii (NTSC-u v1.0)
+* Mario Kart Wii (NTSC-U v1.0)
 
 *More games can be supported upon request!*
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Latest downloads can be found in [releases](https://github.com/bkacjios/m-overla
 * The SpongeBob SquarePants Movie (NTSC v1.1, PAL v1.0)
 * Kirby Air Ride (NTSC-U v1.0, NTSC-J v1.0, [UnclePunch Hack Pack](https://www.kirbyairri.de/hpinfo.html))
 * Super Monkey Ball (NTSC-U v1.0, NTSC-J v1.2, PAL v1.0)
+* Mario Kart Wii (NTSC-u v1.0)
 
 *More games can be supported upon request!*
 

--- a/source/main.lua
+++ b/source/main.lua
@@ -423,7 +423,7 @@ function love.drawControllerOverlay()
 	if controller then
 		-- Draw Joystick
 
-		if controller.plugged and controller.plugged ~= (memory.isKirbyAirRide() and 0x01 or 0x00) then
+		if controller.plugged and controller.plugged ~= (memory.game.pluggedValue or 0x00) then
 			local sin = 128 + math.sin(love.timer.getTime()*2) * 128
 			graphics.setColor(255, 0, 0, sin)
 			graphics.easyDraw(DC_CON, 512-42-16, 256-42-16, 0, 42, 42)

--- a/source/modules/games/GKYE01-0.lua
+++ b/source/modules/games/GKYE01-0.lua
@@ -53,4 +53,6 @@ end
 game.translateAxis = function(x, y) return x, y end
 game.translateTriggers = function(l, r) return l, r end
 
+game.pluggedValue = 0x01 -- value the game sets the controller.plugged byte to
+
 return game

--- a/source/modules/games/GKYJ01-0.lua
+++ b/source/modules/games/GKYJ01-0.lua
@@ -53,4 +53,6 @@ end
 game.translateAxis = function(x, y) return x, y end
 game.translateTriggers = function(l, r) return l, r end
 
+game.pluggedValue = 0x01 -- value the game sets the controller.plugged byte to
+
 return game

--- a/source/modules/games/GMBE8P-0.lua
+++ b/source/modules/games/GMBE8P-0.lua
@@ -1,0 +1,43 @@
+-- Super Monkey Ball (NTSC-U v1.0)
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+local addr = 0x801F3B70
+local offset = 0x3C
+
+local controllers = {
+	[1] = addr + offset * 0,
+	[2] = addr + offset * 1,
+	[3] = addr + offset * 2,
+	[4] = addr + offset * 3,
+}
+
+local controller_struct = {
+	[0x0] = { type = "short",	name = "controller.%d.buttons.pressed" },
+	[0x2] = { type = "sbyte",	name = "controller.%d.joystick.x" },
+	[0x3] = { type = "sbyte",	name = "controller.%d.joystick.y" },
+	[0x4] = { type = "sbyte",	name = "controller.%d.cstick.x" },
+	[0x5] = { type = "sbyte",	name = "controller.%d.cstick.y" },
+	[0x6] = { type = "byte",	name = "controller.%d.analog.l" },
+	[0x7] = { type = "byte",	name = "controller.%d.analog.r" },
+	[0xA] = { type = "byte",	name = "controller.%d.plugged" },
+}
+
+for port, address in ipairs(controllers) do
+	for offset, info in pairs(controller_struct) do
+		game.memorymap[address + offset] = {
+			type = info.type,
+			debug = info.debug,
+			name = info.name:format(port),
+		}
+	end
+end
+
+game.translateAxis = core.translateAxis
+game.translateTriggers = core.translateTriggers
+
+return game

--- a/source/modules/games/GMBJ8P-2.lua
+++ b/source/modules/games/GMBJ8P-2.lua
@@ -1,0 +1,43 @@
+-- Super Monkey Ball (NTSC-J v1.2)
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+local addr = 0x801F10C0
+local offset = 0x3C
+
+local controllers = {
+	[1] = addr + offset * 0,
+	[2] = addr + offset * 1,
+	[3] = addr + offset * 2,
+	[4] = addr + offset * 3,
+}
+
+local controller_struct = {
+	[0x0] = { type = "short",	name = "controller.%d.buttons.pressed" },
+	[0x2] = { type = "sbyte",	name = "controller.%d.joystick.x" },
+	[0x3] = { type = "sbyte",	name = "controller.%d.joystick.y" },
+	[0x4] = { type = "sbyte",	name = "controller.%d.cstick.x" },
+	[0x5] = { type = "sbyte",	name = "controller.%d.cstick.y" },
+	[0x6] = { type = "byte",	name = "controller.%d.analog.l" },
+	[0x7] = { type = "byte",	name = "controller.%d.analog.r" },
+	[0xA] = { type = "byte",	name = "controller.%d.plugged" },
+}
+
+for port, address in ipairs(controllers) do
+	for offset, info in pairs(controller_struct) do
+		game.memorymap[address + offset] = {
+			type = info.type,
+			debug = info.debug,
+			name = info.name:format(port),
+		}
+	end
+end
+
+game.translateAxis = core.translateAxis
+game.translateTriggers = core.translateTriggers
+
+return game

--- a/source/modules/games/GMBP8P-0.lua
+++ b/source/modules/games/GMBP8P-0.lua
@@ -1,0 +1,43 @@
+-- Super Monkey Ball (PAL v1.0)
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+local addr = 0x80225E00
+local offset = 0x3C
+
+local controllers = {
+	[1] = addr + offset * 0,
+	[2] = addr + offset * 1,
+	[3] = addr + offset * 2,
+	[4] = addr + offset * 3,
+}
+
+local controller_struct = {
+	[0x0] = { type = "short",	name = "controller.%d.buttons.pressed" },
+	[0x2] = { type = "sbyte",	name = "controller.%d.joystick.x" },
+	[0x3] = { type = "sbyte",	name = "controller.%d.joystick.y" },
+	[0x4] = { type = "sbyte",	name = "controller.%d.cstick.x" },
+	[0x5] = { type = "sbyte",	name = "controller.%d.cstick.y" },
+	[0x6] = { type = "byte",	name = "controller.%d.analog.l" },
+	[0x7] = { type = "byte",	name = "controller.%d.analog.r" },
+	[0xA] = { type = "byte",	name = "controller.%d.plugged" },
+}
+
+for port, address in ipairs(controllers) do
+	for offset, info in pairs(controller_struct) do
+		game.memorymap[address + offset] = {
+			type = info.type,
+			debug = info.debug,
+			name = info.name:format(port),
+		}
+	end
+end
+
+game.translateAxis = core.translateAxis
+game.translateTriggers = core.translateTriggers
+
+return game

--- a/source/modules/games/RMCE01-0.lua
+++ b/source/modules/games/RMCE01-0.lua
@@ -1,0 +1,50 @@
+-- Mario Kart Wii (NTSC-U, v1.0) (Issue #17)
+
+-- Code based on RSBE01-2.lua
+
+local min = math.min
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+local addr = 0x9037CDBA
+local offset = 0xB0
+
+local controllers = {
+	[1] = addr + offset * 0,
+	[2] = addr + offset * 1,
+	[3] = addr + offset * 2,
+	[4] = addr + offset * 3,
+}
+
+local controller_struct = {
+	[0x00] = { type = "short",	name = "controller.%d.buttons.pressed" },
+	[0x02] = { type = "float",	name = "controller.%d.joystick.x" },
+	[0x06] = { type = "float",	name = "controller.%d.joystick.y" },
+	[0x96] = { type = "float",	name = "controller.%d.cstick.x" },
+	[0x9A] = { type = "float",	name = "controller.%d.cstick.y" },
+	[0x8C] = { type = "byte",	name = "controller.%d.analog.l" },
+	[0x8D] = { type = "byte",	name = "controller.%d.analog.r" },
+	[0x90] = { type = "byte",	name = "controller.%d.plugged" },
+}
+
+for port, address in ipairs(controllers) do
+	for offset, info in pairs(controller_struct) do
+		game.memorymap[address + offset] = {
+			type = info.type,
+			debug = info.debug,
+			name = info.name:format(port),
+		}
+	end
+end
+
+function game.translateAxis(x, y)
+	return x, y
+end
+
+game.translateTriggers = core.translateTriggers
+
+return game

--- a/source/modules/memory/init.lua
+++ b/source/modules/memory/init.lua
@@ -333,15 +333,6 @@ function watcher.isMelee()
 	return gid == "GALE01"
 end
 
-function watcher.isKirbyAirRide()
-	local gid = watcher.gameid
-
-	local clone = clones[gid]
-	if clone then gid = clone.id end
-
-	return (gid == "GKYE01" or gid == "GKYJ01")
-end
-
 function watcher.runhooks()
 	local pop
 	while true do


### PR DESCRIPTION
## Super Monkey Ball
* Added support for Super Monkey Ball, all regions, most recent versions (NTSC-U v1.0, NTSC-J v1.2, PAL v1.0)
* Updated README.md to reflect changes.
## Kirby Air Ride
* Added a field to `memory.game` which determines the proper value of the `controller.plugged` check in `main.lua`.
## Mario Kart Wii
* Added support for Mario Kart Wii (NTSC-U v1.0) [#17]
* Updated README.md to reflect changes.