### PR TITLE
Add support for Wind Waker Randomizer

### DIFF
--- a/source/modules/games/GZLE99-0.lua
+++ b/source/modules/games/GZLE99-0.lua
@@ -1,0 +1,11 @@
+-- The Legend of Zelda: The Wind Waker (NTSC) Randomizer
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+core.loadGenericControllerMap(0x803ED818, game)
+
+return game


### PR DESCRIPTION
Added module from Wind Waker randomizer. This is just a copy of the Wind Waker file with a different file name to enable support.

Using the original NTSC Wind Waker ISO, it randomizes the game to create a new file with the game code GZLE99

![image](https://user-images.githubusercontent.com/9077125/100371692-18415480-3000-11eb-9fd8-a4a9d97ab047.png)

Randomizer can be found here: https://github.com/LagoLunatic/wwrando
