### PR TITLE
Added support for the Japanese version of Luigi's Mansion

### DIFF
--- a/source/modules/games/GLMJ01-0.lua
+++ b/source/modules/games/GLMJ01-0.lua
@@ -1,0 +1,11 @@
+-- Luigi's Mansion (JP v1.0)
+
+local core = require("games.core")
+
+local game = {
+	memorymap = {}
+}
+
+core.loadGenericControllerMap(0x80494778, game)
+
+return game


### PR DESCRIPTION
Added a file named "GLMJ01-0.lua" in \source\modules\games to add support for the Japanese version of Luigi's Mansion!