### PR TITLE
Fix music desyncs when using Slippi as the seed

### DIFF
--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -159,6 +159,9 @@ game.memorymap[CSSDT_BUF_ADDR] = {
 	}
 }
 
+-- https://github.com/project-slippi/slippi-ssbm-asm/blob/9c36ffc5e4787c6caadfb12727c5fcff07d64642/Online/Slippi%20Online%20Scene/main.asm#L634-L637
+game.memorymap[0x804D5F90] = { type = "u32", name = "match.rng_seed" }
+
 -- Where character ID's are stored in the CSS menu
 local player_select_external_addresses = {
 	0x8043208B,

--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -1,5 +1,8 @@
 -- Super Smash Bros. Melee (NTSC v1.2) / Dairantou Smash Brothers DX (Japan v1.2)
 
+local memory = require("memory")
+local bit = require("bit")
+
 local game = {
 	memorymap = {}
 }
@@ -20,7 +23,7 @@ game.memorymap[0x804807C8] = { type = "bool", name = "menu.teams" }
 
 game.memorymap[0x8066A2DF] = { type = "data", len = 7, name = "romstring.akaneia" }
 game.memorymap[0x8066A2C3] = { type = "data", len = 12, name = "romstring.beyondmelee" }
-   
+ 
 local controllers = {
 	[1] = 0x804C1FAC + 0x44 * 0,
 	[2] = 0x804C1FAC + 0x44 * 1,
@@ -159,8 +162,17 @@ game.memorymap[CSSDT_BUF_ADDR] = {
 	}
 }
 
--- https://github.com/project-slippi/slippi-ssbm-asm/blob/9c36ffc5e4787c6caadfb12727c5fcff07d64642/Online/Slippi%20Online%20Scene/main.asm#L634-L637
--- game.memorymap[0x804D5F90] = { type = "u32", name = "match.rng_seed" }
+-- https://github.com/project-slippi/slippi-ssbm-asm/blob/9c36ffc5e4787c6caadfb12727c5fcff07d64642/Online/Online.s#L10
+local ONLINE_BUF_ADDR = 0x804D6CBC
+
+game.memorymap[ONLINE_BUF_ADDR] = {
+	type = "pointer",
+	name = "online",
+	struct = {
+		-- https://github.com/project-slippi/slippi-ssbm-asm/blob/9c36ffc5e4787c6caadfb12727c5fcff07d64642/Online/Online.s#L182-L225
+		[0x07] = { type = "u32", name = "rng_offset" }
+	}
+}
 
 -- Where character ID's are stored in the CSS menu
 local player_select_external_addresses = {

--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -160,7 +160,7 @@ game.memorymap[CSSDT_BUF_ADDR] = {
 }
 
 -- https://github.com/project-slippi/slippi-ssbm-asm/blob/9c36ffc5e4787c6caadfb12727c5fcff07d64642/Online/Slippi%20Online%20Scene/main.asm#L634-L637
-game.memorymap[0x804D5F90] = { type = "u32", name = "match.rng_seed" }
+-- game.memorymap[0x804D5F90] = { type = "u32", name = "match.rng_seed" }
 
 -- Where character ID's are stored in the CSS menu
 local player_select_external_addresses = {

--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -139,7 +139,7 @@ game.memorymap[CSSDT_BUF_ADDR] = {
 				[0x02] = { type = "u8", name = "remote_player.ready" },
 				[0x03] = { type = "u8", name = "local_player.index", debug = true },
 				[0x04] = { type = "u8", name = "remote_player.index" },
-				[0x05] = { type = "u32", name = "rng_offset", debug = true },
+				[0x05] = { type = "u32", name = "rng_offset" },
 				[0x09] = { type = "u8", name = "delay_frames" },
 				[0x0A] = { type = "u8", name = "local_player.chatmsg_id" },
 				[0x0B] = { type = "u8", name = "opponent.chatmsg_id" },

--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -1,8 +1,5 @@
 -- Super Smash Bros. Melee (NTSC v1.2) / Dairantou Smash Brothers DX (Japan v1.2)
 
-local memory = require("memory")
-local bit = require("bit")
-
 local game = {
 	memorymap = {}
 }

--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -136,7 +136,7 @@ game.memorymap[CSSDT_BUF_ADDR] = {
 				[0x02] = { type = "u8", name = "remote_player.ready" },
 				[0x03] = { type = "u8", name = "local_player.index", debug = true },
 				[0x04] = { type = "u8", name = "remote_player.index" },
-				[0x05] = { type = "u32", name = "rng_offset" },
+				[0x05] = { type = "u32", name = "rng_offset", debug = true },
 				[0x09] = { type = "u8", name = "delay_frames" },
 				[0x0A] = { type = "u8", name = "local_player.chatmsg_id" },
 				[0x0B] = { type = "u8", name = "opponent.chatmsg_id" },

--- a/source/music.lua
+++ b/source/music.lua
@@ -423,7 +423,7 @@ function music.loadForStage(stageid)
 	if not memory.isMelee() or not PANEL_SETTINGS:PlayStageMusic() then return end
 
 	local seed
-	if stageid == 0 then
+	if stageid == 0x0 then
 		seed = music.RNG_OFFSET
 		if seed == 0 then
 			seed = os.time()

--- a/source/music.lua
+++ b/source/music.lua
@@ -214,7 +214,7 @@ end)
 
 memory.hook("slippi.connection_state", "Check Slippi connection", function(state)
 	if state == 0x4 then
-		log.debug("[MUSIC] Slippi connection successful.")
+		log.debug("[MUSIC] Slippi connection successful")
 		music.NEW_CONNECTION = true
 	end
 end)

--- a/source/music.lua
+++ b/source/music.lua
@@ -408,14 +408,17 @@ function music.loadForStage(stageid)
 	music.kill()
 	if not memory.isMelee() or not PANEL_SETTINGS:PlayStageMusic() then return end
 
-	math.randomseed(memory.slippi.rng_offset)
+	local rng_offset = memory.slippi.rng_offset
+	if rng_offset ~= 0 then	
+		math.randomseed(memory.slippi.rng_offset)
 
-	local values = {}
-	for i=1,8 do
-		table.insert(values, math.random(1, 255))
+		local values = {}
+		for i=1,8 do
+			table.insert(values, math.random(1, 255))
+		end
+		local data = string.char(unpack(values))
+		log.debug("[RANDOM] Flushing random of initial values (0x%s)", string.tohex(data))
 	end
-	local data = string.char(unpack(values))
-	log.debug("[RANDOM] Flushing random of initial values (0x%s)", string.tohex(data))
 
 	music.PLAYLIST_ID = stageid
 

--- a/source/music.lua
+++ b/source/music.lua
@@ -485,8 +485,6 @@ function music.loadForStage(stageid)
 		music.loadStageMusicInDir(stageid, ("Melee/Series Music/%s"):format(series)) -- Load everything in the series folder
 		music.loadStageMusicInDir(stageid, "Melee/Series Music") -- Load everything that's not in a stage folder as well
 	end
-
-
 end
 
 return music

--- a/source/music.lua
+++ b/source/music.lua
@@ -6,7 +6,7 @@ local music = {
 	LOOP = false,
 	USE_WEIGHTS = false,
 	TRACK_NUMBER = {},
-	RNG_OFFSET = os.time(), -- use the system clock as initial seed
+	RNG_OFFSET = os.time(), -- Use the system clock as initial seed
 	NEW_CONNECTION = false,
 }
 
@@ -472,7 +472,7 @@ function music.loadForStage(stageid)
 		music.loadStageMusicInDir(stageid, "Melee/Series Music") -- Load everything that's not in a stage folder as well
 	end
 
-	music.RNG_OFFSET = bit.bxor(music.RNG_OFFSET, 397) -- advance the seed in a deterministic but unpredictable way using xor
+	music.RNG_OFFSET = bit.bxor(music.RNG_OFFSET, 397) -- Advance the seed in a deterministic but unpredictable way using xor
 	math.randomseed(music.RNG_OFFSET)
 	
 	local values = {}

--- a/source/music.lua
+++ b/source/music.lua
@@ -205,6 +205,7 @@ memory.hook("volume.slider", "Ingame Volume Adjust", function(volume)
 end)
 
 function music.updateRNGseed(seed)
+	if seed == 0 then seed = os.time() end
 	math.randomseed(seed)
 	music.RNG_OFFSET = seed
 	local values = {}
@@ -429,18 +430,17 @@ function music.loadForStage(stageid)
 	music.PLAYLIST = {}
 	music.USE_WEIGHTS = false
 
-	local seed
-	if stageid == 0x0 then
-		seed = music.RNG_OFFSET
-		if seed == 0 then
-			seed = os.time()
+	local seed = 0
+	if PANEL_SETTINGS:IsSlippiNetplay() then
+		if stageid == 0x0 then
+			seed = music.RNG_OFFSET
+			if seed ~= 0 then
+				-- Advance the seed in a deterministic way by incrementing it
+				seed = seed + 1
+			end
 		else
-			-- Advance the seed in a deterministic way by incrementing it
-			seed = seed + 1
+			seed = memory.online.rng_offset
 		end
-	else
-		seed = memory.online.rng_offset
-		if seed == 0 then seed = os.time() end
 	end
 	music.updateRNGseed(seed)
 

--- a/source/music.lua
+++ b/source/music.lua
@@ -204,13 +204,6 @@ memory.hook("volume.slider", "Ingame Volume Adjust", function(volume)
 	end
 end)
 
-memory.hook("slippi.connection_state", "Check Slippi connection", function(state)
-	if state == 0x4 then
-		log.debug("[MUSIC] Slippi connection successful")
-		music.NEW_CONNECTION = true
-	end
-end)
-
 function music.setVolume(vol)
 	if ALLOW_INGAME_VOLUME and memory.isMelee() then
 		-- Melee's slider goes in increments of 5
@@ -415,7 +408,7 @@ function music.loadForStage(stageid)
 	music.kill()
 	if not memory.isMelee() or not PANEL_SETTINGS:PlayStageMusic() then return end
 
-	math.randomseed(memory.match.rng_seed)
+	math.randomseed(memory.slippi.rng_offset)
 
 	local values = {}
 	for i=1,8 do

--- a/source/music.lua
+++ b/source/music.lua
@@ -15,7 +15,6 @@ local memory = require("memory")
 local notification = require("notification")
 local overlay = require("overlay")
 local wav = require("wav")
-local bit = require("bit")
 
 require("extensions.math")
 
@@ -436,8 +435,8 @@ function music.loadForStage(stageid)
 		if seed == 0 then
 			seed = os.time()
 		else
-			-- Advance the seed in a deterministic but unpredictable way using xor
-			seed = bit.bxor(seed, 397)
+			-- Advance the seed in a deterministic way by incrementing it
+			seed = seed + 1
 		end
 	else
 		seed = memory.online.rng_offset


### PR DESCRIPTION
Fixes #101.

This uses a different offset from the one currently in the `slippi` struct. See the GitHub URLs in the code for details.

This will always sync when possible. When a Slippi seed is not found, it will fall back to the system time as a seed.

Because the CSS in Slippi does not use shared RNG (so that players can random different characters), a new seed is derived from the previous match instead of from the Slippi seed when in the menu.