### PR TITLE
Streamline RNG seed acquisition and refresh seed when panel changes

### DIFF
--- a/source/modules/games/GALE01-2.lua
+++ b/source/modules/games/GALE01-2.lua
@@ -21,6 +21,8 @@ game.memorymap[0x804807C8] = { type = "bool", name = "menu.teams" }
 game.memorymap[0x8066A2DF] = { type = "data", len = 7, name = "romstring.akaneia" }
 game.memorymap[0x8066A2C3] = { type = "data", len = 12, name = "romstring.beyondmelee" }
 
+game.memorymap[0x804D5F90] = { type = "u32", name = "rng.seed" }
+
 local controllers = {
 	[1] = 0x804C1FAC + 0x44 * 0,
 	[2] = 0x804C1FAC + 0x44 * 1,

--- a/source/modules/gui/panels/settings.lua
+++ b/source/modules/gui/panels/settings.lua
@@ -105,6 +105,7 @@ function PANEL:Settings()
 
 	function self.SLIPPI.MODE:OnSelectOption(num)
 		self:GetParent():SetBackgroundColor(num == SLIPPI_OFF and color(100, 100, 100, 150) or color(33, 186, 69, 150))
+		music.refreshRNGseed()
 	end
 
 	self.MELEE.MUSIC = self.MELEE:Add("Checkbox")


### PR DESCRIPTION
This is a minor update to the RNG functionality. Fixes three things:
1. Whenever the Slippi panel setting is changed, the seed will be rerolled.
2. Better handling of different RNG sources. If the game is not Melee, it will use the system time. If it is Melee but not netplay, it will use the Melee RNG seed. If it is Slippi but in the menu, it will use the previous seed. Finally, if it is Slippi and a match, it will use the Slippi seed.
3. The debug output was cleaned up to only show the seed (instead of flushing values) and the source of the seed is displayed.