### PR TITLE
Simplify RNG seed logic

### DIFF
--- a/source/music.lua
+++ b/source/music.lua
@@ -206,15 +206,10 @@ end)
 
 function music.refreshRNGseed()
 	local getSeed = function()
-		if not memory.isMelee() then return os.time(), "the system time" end
-		if not PANEL_SETTINGS:IsSlippiNetplay() then return memory.rng.seed, "Melee" end
-
-		if melee.isInMenus() then
-			if music.RNG_SEED then return music.RNG_SEED + 1, "the previous seed" end
-			return memory.rng.seed, "Melee"
-		end
-
-		return memory.online.rng_offset, "Slippi"
+		if not music.RNG_SEED or not memory.isMelee() then return os.time(), "the system time" end
+		if melee.isInMenus() then return music.RNG_SEED + 1, "the previous seed" end
+		if PANEL_SETTINGS:IsSlippiNetplay() then return memory.online.rng_offset, "Slippi" end
+		return memory.rng.seed, "Melee"
 	end
 
 	local seed, source = getSeed()


### PR DESCRIPTION
Sorry for yet another seed change. This should be the last one.

The problem is that sometimes, in the menus, the Melee RNG seed is never updated so you get the same songs when opening the game for the first time.

This version will always use the previous seed in the menus. It will only use the Melee seed when both offline (`not PANEL_SETTINGS:IsSlippiNetplay()`) and in a match.