### PR TITLE
 Lazily load music tracks as they are needed

### DIFF
--- a/source/music.lua
+++ b/source/music.lua
@@ -281,12 +281,7 @@ function music.playNextTrack()
 				return nil
 			end
 
-			local wavinfo
-			if track_info.IS_WAV then
-				wavinfo = wav.parse(track_info.FILEPATH)
-			end
-			
-			return { STREAM = source, WAV = wavinfo }
+			return { STREAM = source, WAV = track_info.IS_WAV and wav.parse(filepath) or nil }
 		end
 
 		local track = getTrack()


### PR DESCRIPTION
Fixes #104.

This results in a considerable speedup when changing scenes as well as much less memory usage.

I would like to improve the error handling (when an invalid track is encountered), but I feel that should be left for a separate PR.