### PR TITLE
Do not refresh RNG seed when settings are changed

### DIFF
--- a/source/modules/gui/panels/settings.lua
+++ b/source/modules/gui/panels/settings.lua
@@ -109,7 +109,6 @@ function PANEL:Settings()
 
 	function self.SLIPPI.MODE:OnSelectOption(num)
 		self:GetParent():SetBackgroundColor(num == SLIPPI_OFF and color(100, 100, 100, 255) or color(33, 186, 69, 255))
-		music.refreshRNGseed()
 	end
 
 	self.MELEE.MUSIC = self.MELEE.LEFT:Add("Checkbox")


### PR DESCRIPTION
This is no longer necessary, because `melee.isNetplayGame()` reads from the game memory and not from the panel settings.