### PR TITLE
Fixed C-stick going out of radius for Pac-Man World 2

### DIFF
--- a/source/modules/games/GP2EAF-0.lua
+++ b/source/modules/games/GP2EAF-0.lua
@@ -19,4 +19,6 @@ function game.translateJoyStick(x, y)
 	return x + math.sin(angle) * mag * near * 0.25, y + math.cos(angle) * mag * near * 0.25
 end
 
+game.translateCStick = game.translateJoyStick
+
 return game


### PR DESCRIPTION
Seems in the last release the c-stick graphic would go out of the notch radius. I've attempted to fix that here and it seems to work on my end.