### PR TITLE
Add Support for 2 Bionicle Games

### DIFF
--- a/source/modules/games/GVHE4F-1.lua
+++ b/source/modules/games/GVHE4F-1.lua
@@ -1,0 +1,5 @@
+-- Bionicle Heroes (NTSC-U v1.1)
+
+local core = require("games.core")
+
+return core.newGame(0x0803722A0)

--- a/source/modules/games/GVOE69-0.lua
+++ b/source/modules/games/GVOE69-0.lua
@@ -1,0 +1,5 @@
+-- BIONICLE (NTSC-U v1.0)
+
+local core = require("games.core")
+
+return core.newGame(0x8018AB14)


### PR DESCRIPTION
Adds support for:
- Bionicle: The Game NTSC-U (GVOE69)
- Bionicle Heroes NTSC-U (GVHE4F-1)
Love Version: 11.5
Tested multiple times however the changes were never properly detected in generated EXEs when using the "release.bat".
However, using it how it is described in the "run.sh" script it works and detects the new game. 


Would be nice if somebody could explain what I did wrong with the build process.

Edit: Seems like I figured out a way to generate a proper EXE. I just take the application.love and manually package that into an exe with the modified love.exe, for some reason it doesnt wanna do that automatically. 

The executable has been tested by others and they could confirm that both games' input is being detected correctly.