### PR TITLE
Adds support for Sonic Riders

### DIFF
--- a/source/modules/games/GXEE8P-0.lua
+++ b/source/modules/games/GXEE8P-0.lua
@@ -1,0 +1,5 @@
+-- Sonic Riders (NTSC-U v1.0)
+
+local core = require("games.core")
+
+return core.newGame(0x801AF9C0)

--- a/source/modules/games/GXSRTE-0.lua
+++ b/source/modules/games/GXSRTE-0.lua
@@ -1,0 +1,5 @@
+-- Sonic Riders Tournament Edition (2.3)
+
+local core = require("games.core")
+
+return core.newGame(0x804B6F50)

--- a/source/modules/games/GXSRTE-0.lua
+++ b/source/modules/games/GXSRTE-0.lua
@@ -1,5 +1,0 @@
--- Sonic Riders Tournament Edition (2.3)
-
-local core = require("games.core")
-
-return core.newGame(0x804B6F50)


### PR DESCRIPTION
Includes support for Sonic Riders NTSC-U [GXEE8P]

(First commit mentions SRTE 2.3, this was removed)